### PR TITLE
Fix sync failure by adding missing import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "tabtogether",
- "version": "0.12.4",
- "lockfileVersion": 3,
+  "version": "0.12.4",
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {

--- a/ui/options/options.js
+++ b/ui/options/options.js
@@ -9,7 +9,7 @@ import {
   getUnifiedState,
   getDefinedGroupsFromBookmarks,
 } from "../../core/actions.js";
-import { storage } from "../../core/storage.js";
+import { storage, recordSuccessfulSyncTime } from "../../core/storage.js";
 import { processSubscribedGroupTasks } from "../../core/tasks.js";
 import { debounce } from "../../common/utils.js";
 import {


### PR DESCRIPTION
Added missing import of `recordSuccessfulSyncTime` in `ui/options/options.js` which caused sync to fail with `recordSuccessfulSyncTime is not defined`.

---
*PR created automatically by Jules for task [9153538957413097770](https://jules.google.com/task/9153538957413097770) started by @ophilar*